### PR TITLE
update lodash to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "bluebird": "3.4.6",
     "graceful-fs": "4.1.10",
     "gulp-util": "3.0.7",
-    "lodash": "4.17.2",
+    "lodash": "4.17.21",
     "npm": "4.0.2",
     "through2": "2.0.1"
   },


### PR DESCRIPTION
address security vulnerability
https://nvd.nist.gov/vuln/detail/CVE-2019-10744
https://github.com/advisories/GHSA-jf85-cpcp-j695